### PR TITLE
rect extensions (operators), MoveBy, MoveTo.wx

### DIFF
--- a/modules/std/geom/rect.wx
+++ b/modules/std/geom/rect.wx
@@ -360,11 +360,31 @@ Struct Rect<T>
 	Method Intersects:Bool( r:Rect )
 		Return r.max.x>min.x And r.min.x<max.x And r.max.y>min.y And r.min.y<max.y
 	End
+
+	#rem wonkeydoc Move the rect.
+	@adapted iDkP 2025-06-02
+	@param dx the new location
+	@param dy the new location
+	#end
+	Method MoveTo( x:T,y:T )
+		Local size:=Self.Size
+		Self.Origin=New Vec2<T>( x,y )
+		Self.Size=size
+	End
+	
+	#rem wonkeydoc Move the rect.
+	@adapted iDkP 2025-06-02
+	@param dx the quantity of mouvement
+	@param dy the quantity of mouvement
+	#end
+	Method MoveBy( dx:T,dy:T ) Where T Implements INumeric 
+		Local size:=Self.Size
+		Self.Origin=Self.Origin+New Vec2<T>( dx,dy )
+		Self.Size=size
+	End
 	
 	#rem wonkeydoc Gets a string describing the rect.
-	
-	Deprecated: Use Operator To:String instead.
-	
+	@deprecated: Use Operator To:String instead.
 	#end
 	Method ToString:String()
 		Return Self
@@ -613,4 +633,3 @@ Function TransformRecti<T>:Recti( rect:Recti,matrix:AffineMat3<T> )
 		
 	Return New Recti( Round( min.x ),Round( min.y ),Round( max.x ),Round( max.y ) )
 End
-


### PR DESCRIPTION
	In utils/Utils:
	Recti Extension Undoned and move in rect, making it generic by the way
	Stack operators extension undoned and moved in Stack

This original code was developped by:
Co-authored-by: marksibly <marksibly@zohomail.com>
Co-authored-by: seyhajin <seyhajin@gmail.com>
Co-authored-by: D-a-n-i-l-o<D-a-n-i-l-o@users.noreply.github.com.com>
Co-authored-by: engor<engor@yandex.ru>
Co-authored-by: arawkins<arawkins@gmail.com>
Co-authored-by: XANOZOID<XANOZOID@users.noreply.github.com.com>
Co-authored-by: jacereda<jacereda@users.noreply.github.com.com>
Co-authored-by: LucasWolschick<LucasWolschick@users.noreply.github.com.com>
Co-authored-by: abakobo <abakobo@users.noreply.github.com.com>