### PR TITLE
Divers patches

### DIFF
--- a/modules/std/collections/list.wx
+++ b/modules/std/collections/list.wx
@@ -14,15 +14,10 @@ Alias FloatList:List<Float>
 Alias StringList:List<String>
 
 #rem wonkeydoc The List class provides support for linked lists.
-
 A linked list is a container style data structure that provides efficient support for the addition, removal and sequential traversal of objects.
-
 A linked list works by connecting elements together with 'next' and 'previous' references, making it very efficient to get from one element to the next, but not so efficient for accessing arbitrary elements.
-
 This connection between elements is achieved using separate Node objects (there is one per element) which contain references to the next and previous nodes in the list, as well as the actual object managed by the node.
-
 Lists implements the [[IContainer]] interface so can be used with Eachin loops.
-
 #end
 Class List<T> Implements IContainer<T>
 
@@ -47,11 +42,8 @@ Class List<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Creates a new node with the given successor node.
-		
 		Warning! No error checking is performed!
-		
 		This method should not be used while iterating over the list containing `succ`.
-		
 		#end
 		Method New( value:T,succ:Node )
 			_value=value
@@ -82,11 +74,8 @@ Class List<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Removes this node.
-		
 		Warning! No error checking is performed!
-		
 		This method should not be used while iterating over the list containing this node.
-		
 		#end
 		Method Remove()
 			If _succ._pred<>Self Or _pred._succ<>Self Return
@@ -95,11 +84,8 @@ Class List<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Inserts the node before another node.
-		
 		If the node is already in a list, it is removed before insertion.
-		
 		This method should not be used while iterating over the list containing this node or `node`.
-		
 		#end
 		Method InsertBefore( node:Node ) Virtual 
 			Remove()
@@ -111,11 +97,8 @@ Class List<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Inserts the node after another node.
-		
 		If the node is already in a list, it is removed before insertion.
-		
 		This method should not be used while iterating over the list containing this node or `node`.
-		
 		#end
 		Method InsertAfter( node:Node ) Virtual 
 			Remove()
@@ -125,14 +108,6 @@ Class List<T> Implements IContainer<T>
 			_succ._pred=Self
 			node._succ=Self
 		End
-		
-		'hidden
-		Method RemoveFast() 'added by iDkP
-			'No bound checking - Pure Pointer manipulation
-			_pred._succ = _succ
-			_succ._pred = _pred
-		End
-		
 	End
 	
 	#rem wonkeydoc The List.Iterator struct.
@@ -182,12 +157,9 @@ Class List<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Safely erases the node referenced by the iterator.
-		
 		After calling this method, the iterator will point to the node after the removed node.
-		
 		Therefore, if you are manually iterating through a list you should not call [[Bump]] after calling this method or you
 		will end up skipping a node.
-		
 		#end
 		Method Erase()
 			AssertCurrent()
@@ -196,9 +168,7 @@ Class List<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Safely insert a value before the iterator.
-
 		After calling this method, the iterator will point to the newly added node.
-		
 		#end
 		Method Insert( value:T )
 			_node=New Node( value,_node )
@@ -252,12 +222,9 @@ Class List<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Safely erases the node referenced by the iterator.
-		
 		After calling this method, the iterator will point to the node after the removed node.
-		
 		Therefore, if you are manually iterating through a list you should not call [[Bump]] after calling this method or you
 		will end up skipping a node.
-		
 		#end
 		Method Erase()
 			AssertCurrent()
@@ -266,9 +233,7 @@ Class List<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Safely insert a value before the iterator.
-
 		After calling this method, the iterator will point to the newly added node.
-		
 		#end
 		Method Insert( value:T )
 			_node=New Node( value,_node._succ )
@@ -282,17 +247,11 @@ Class List<T> Implements IContainer<T>
 	Public
 	
 	#rem wonkeydoc Creates a new list.
-	
 	New() create a new empty list.
-	
 	New( T[] ) creates a new list with the elements of an array.
-	
 	New( List<T> ) creates a new list with the contents of another list.
-	
 	New( Stack<T> ) create a new list the contents of a stack.
-	
 	@param values An existing array, list or stack.
-	
 	#end
 	Method New()
 		_head=New Node( Null )
@@ -314,42 +273,31 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Gets an iterator for visiting list values.
-	
 	Returns an iterator suitable for use with Eachin, or for manual iteration.
-	
 	@return A list iterator.
-	
 	#end
 	Method All:Iterator()
 		Return New Iterator( Self,_head._succ )
 	End
 
 	#rem wonkeydoc Gets an iterator for visiting list values in reverse order.
-	
 	Returns an iterator suitable for use with Eachin, or for manual iteration.
-	
 	@return A backwards list iterator.
-	
 	#end	
 	Method Backwards:BackwardsIterator()
 		Return New BackwardsIterator( Self,_head._pred )
 	End
 	
 	#rem wonkeydoc Checks whether the list is empty.
-	
 	@return True if the list is empty.
-	
 	#end
 	Property Empty:Bool()
 		Return _head._succ=_head
 	End
 
 	#rem wonkeydoc Gets the first value in the list.
-	
 	In debug builds, a runtime error will occur if the list is empty.
-	
 	@return The first value in the list.
-	
 	#end
 	Property First:T()
 		DebugAssert( Not Empty )
@@ -358,11 +306,8 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Gets the last value in the list
-	
 	In debug builds, a runtime error will occur if the list is empty.
-	
 	@return The last value in the list.
-	
 	#end
 	Property Last:T()
 		DebugAssert( Not Empty )
@@ -373,16 +318,12 @@ Class List<T> Implements IContainer<T>
 	'---- iDkP added: HasOne, HasTwo, HasOneOrTwo, HasMore, HasLess ----
 
 	#rem wonkeydoc Test if the list has only one element
-	
+	@author iDkP from GaragePixel
+	@since 2025-05-11
 	@return False if the list's empty of has more one elements.
-	
 	@return True if the list has exactly one element.
-	
 	#end
 	Property HasOne:Bool() 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
 		'
 		' Return true if the list has one item (no more)
 		'
@@ -390,16 +331,12 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Test if the list has exactly two elements
-	
+	@author iDkP from GaragePixel
+	@since 2025-05-11
 	@return False if the list's empty of has one or more two elements.
-	
 	@return True if the list has exactly two elements.
-	
 	#end
 	Property HasTwo:Bool() 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
 		'
 		' Return true if the list has two items (no more)
 		'
@@ -407,20 +344,14 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Test if the list has one or two elements
-	
+	@author iDkP from GaragePixel
+	@since 2025-05-11
 	@return -1 if the list's 'some elements' but empty, one or two elements
-	
 	@return 0 if the list's empty
-	
 	@return 1 if the list has exactly one element.
-	
 	@return 2 if the list has exactly two elements.
-	
 	#end	
 	Property HasOneOrTwo:Byte() 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
 		'
 		' Returns...
 		'	-1 = neither empty, 1 or 2 (meaning 'has more than two and is not empty')
@@ -435,17 +366,15 @@ Class List<T> Implements IContainer<T>
 		Return HasOne ? 1 Else ( HasTwo ? 2 Else ( Empty ? -1 Else 0 ) )
 	End 	
 
-	#rem wonkeydoc Returns if the list has less than n items.
-	
+	#rem wonkeydoc Returns if the list has less than n items.	
 	Note: This method can be slow when used with large lists, as it must visit each value.
+	@author iDkP from GaragePixel
+	@since 2025-05-13
 	But if the method count until nbItems, it will stop counting and returns the answer.
 	So it's faster than using Count() if we want only know if the list has less than nbItems.
-
 	@return True if the list has less items than nbItems' value.
-	
 	#end
-	Method HasLess:Bool( nbItems:UInt ) 'Added by iDkP
-		'iDkP 2025-05-13
+	Method HasLess:Bool( nbItems:UInt )
 		Local node:=_head._succ,n:=0
 		While node<>_head Or n<nbItems
 			node=node._succ
@@ -455,16 +384,14 @@ Class List<T> Implements IContainer<T>
 	End 
 
 	#rem wonkeydoc Returns if the list has more than n items.
-	
+	@author iDkP from GaragePixel
+	@since 2025-05-13	
 	Note: This method can be slow when used with large lists, as it must visit each value.
 	But if the method count above nbItems, it will stop counting and returns the answer.
 	So it's faster than using Count() if we want only know if the list has more than nbItems.
-
 	@return True if the list has more items than nbItems' value.
-	
 	#end
-	Method HasMore:Bool( nbItems:UInt ) 'Added by iDkP
-		'iDkP 2025-05-13
+	Method HasMore:Bool( nbItems:UInt )
 		Local result:Bool=True
 		Local node:=_head._succ,n:=0
 		While node<>_head
@@ -477,23 +404,18 @@ Class List<T> Implements IContainer<T>
 		Wend
 		Return result
 	End 
-	
-	'---- iDkP added: To:Map, ToMapByte, ToMapUByte, ToMapInt, ToMapUInt, ToMapLong, ToMapULong, FromMap ----
+
+	'---- iDkP added: To:Map, ToMapUByte, ToMapShort, ToMapInt ----
 
 	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
-	
+	@author iDkP from GaragePixel
+	@since 2025-05-10
 	The value is prefilled with an index that you can override after.
-	
 	As the key is unique, the index (as map's value) is also unique.
 	If you want make the value set to Null (smallest memory print), use ToMap methods instead.
-	
 	@return The new map as Map<T,UInt>
-	
 	#end
-	Operator To:Map<T,UInt>() 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-10
+	Operator To:Map<T,UInt>()
 		'
 		'Let's say, alternated version, where the list item become the map key 
 		'(map as a set: only one occurance accepted)
@@ -506,65 +428,17 @@ Class List<T> Implements IContainer<T>
 		End
 		Return map
 	End
-	
-	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
-	
-	defValue will populate the new values of the map.
-	You can populate with an index if you prefere.
-	
-	@param deValue the default value who will populate the map as Value
-	
-	@param populateWithIdx if True, the map's values will be populated with a index in the range -128,128.
-	
-	@return The new map as Map<T,Byte>
-	
-	#end
-	Method ToMapByte:Map<T,Byte>( defValue:Byte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
-		'
-		' Let's say, alternated version, where the list item become the map key 
-		' Special version with lighter memory print, 
-		' for specific usage where the value isn't important (smallest datatype)
-		' and if Byte must contains negative values (-128,128)
-		' (map as a set: only one occurance accepted)
-		#rem Bug 
-			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
-			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
-		#end 
-		'
-		Local map:=New Map<T,Byte>()
-		If populateWithIdx 
-			Local offset:Byte=-128
-			For Local item:=Eachin Self
-				map.Set(item,offset)
-				offset+=1
-			End
-		Else 
-			For Local item:=Eachin Self
-				map.Set(item,defValue)
-			End
-		End 
-		Return map
-	End
 
 	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
-	
+	@author iDkP from GaragePixel
+	@since 2025-05-11
 	defValue will populate the new values of the map.
 	You can populate with an index if you prefere.
-	
-	@param deValue the default value who will populate the map as Value
-	
-	@param populateWithIdx if True, the map's values will be populated with a index in the range 0,255.
-	
+	@param deValue the default value who will populate the map as Value	
+	@param populateWithIdx if True, the map's values will be populated with a index in the range 0,255.	
 	@return The new map as Map<T,UByte>
-	
 	#end
-	Method ToMapUByte:Map<T,UByte>( defValue:UByte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
+	Method ToMapUByte:Map<T,UByte>( defValue:Bool=Null, populateWithIdx:Bool=False )
 		'
 		' Let's say, alternated version, where the list item become the map key 
 		' Special version with lighter memory print, 
@@ -591,199 +465,43 @@ Class List<T> Implements IContainer<T>
 		Return map
 	End
 
-	#rem wonkeydoc Made a list from the map's values.
-	Explicitly declare your List type as same than your map's value's type to set up the overloading.
-	Note: Map must has a different type of key from value.
-	
-	@param onPlace if False, returns a copy of the list, else operates on the list directly.
-	
-	@return a copy of the list if onPlace=False
-	
-	#end	
-	Method FromMap<T2>:List<T>( map:Map<T2,T>, onPlace:Bool=True ) 'Added by iDkP
-		result = onPlace ? Self Else Copy()
-		result.Clear()
-		For Local item:=Eachin map 
-			result.Add(item)
-		End 
-		Return result
-	End
-
-	#rem wonkeydoc Made a list from the map's keys.
-	Explicitly declare your List type as same than your map's key's type to set up the overloading.
-	Note: Map must has a different type of key from value.
-	
-	@param onPlace if False, returns a copy of the list, else operates on the list directly.
-	
-	@return a copy of the list if onPlace=False
-	
-	#end
-	Method FromMap<T2>:List<T>( map:Map<T,T2>, onPlace:Bool=True ) 'Added by iDkP
-		result = onPlace ? Self Else Copy()
-		result.Clear()
-		For Local item:=Eachin map .Key
-			result.Add(item)
-		End 
-		Return result
-	End
-
 	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
-	
+	@author iDkP from GaragePixel
+	@since 2025-05-11
 	defValue will populate the new values of the map.
 	You can populate with an index if you prefere.
-	
 	@param deValue the default value who will populate the map as Value
-	
 	@param populateWithIdx if True, the map's values will be populated with a index in the range -2147483648,2147483648.
-	
 	@return The new map as Map<T,UByte>
-	
 	#end
-	Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False ) 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
-		'
-		'Let's say, normal version, where the list item become the map value
-		#rem Bug 
-			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
-			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
-		#end 
-		Local map:=New Map<Int,T>()
-		If populateWithIdx 
-			Local offset:Int=-2147483648 'TODO, change for the const
-			For Local item:=Eachin Self
-				map.Set(offset,item)
-				offset+=1
-			End
-		Else 
-			For Local item:=Eachin Self
-				map.Set(defValue,item)
-			End
-		End 
-		Return map
-	End
-
-	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
-	
-	defValue will populate the new values of the map.
-	You can populate with an index if you prefere.
-	
-	@param deValue the default value who will populate the map as Value
-	
-	@param populateWithIdx if True, the map's values will be populated with a index in the range 0,4294967296.
-	
-	@return The new map as Map<T,UByte>
-	
-	#end
-	Method ToMapUInt:Map<UInt,T>( defValue:UInt=Null, populateWithIdx:Bool=False ) 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
-		'
-		'Let's say, normal version, where the list item become the map value
-		#rem Bug 
-			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
-			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
-		#end 
-		Local map:=New Map<UInt,T>()
-		If populateWithIdx 
-			Local offset:UInt=0
-			For Local item:=Eachin Self
-				map.Set(offset,item)
-				offset+=1
-			End
-		Else 
-			For Local item:=Eachin Self
-				map.Set(defValue,item)
-			End
-		End 
-		Return map
-	End
-
-	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
-	
-	defValue will populate the new values of the map.
-	You can populate with an index if you prefere.
-	
-	@param deValue the default value who will populate the map as Value
-	
-	@param populateWithIdx if True, the map's values will be populated with a index in the range -9223372036854775808,9223372036854775808.
-	
-	@return The new map as Map<T,UByte>
-	
-	#end
-	Method ToMapLong:Map<Long,T>( defValue:Long=Null, populateWithIdx:Bool=False ) 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
-		'
-		'Let's say, normal version, where the list item become the map value
-		#rem Bug 
-			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
-			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
-		#end 
-		Local map:=New Map<Long,T>()
-		If populateWithIdx 
-			Local offset:UInt=0
-			For Local item:=Eachin Self
-				map.Set(offset,item)
-				offset+=1
-			End
-		Else 
-			For Local item:=Eachin Self
-				map.Set(defValue,item)
-			End
-		End 
-		Return map
-	End
-
-	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
-	
-	defValue will populate the new values of the map.
-	You can populate with an index if you prefere.
-	
-	@param deValue the default value who will populate the map as Value
-	
-	@param populateWithIdx if True, the map's values will be populated with a index in the range 0,18446744073709551615.
-	
-	@return The new map as Map<T,UByte>
-	
-	#end
-	Method ToMapULong:Map<ULong,T>( defValue:ULong=Null, populateWithIdx:Bool=False ) 'Added by iDkP
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
-		'
-		'Let's say, normal version, where the list item become the map value
-		#rem Bug 
-			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
-			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
-		#end 
-		Local map:=New Map<ULong,T>()
-		If populateWithIdx 
-			Local offset:UInt=0
-			For Local item:=Eachin Self
-				map.Set(offset,item)
-				offset+=1
-			End
-		Else 
-			For Local item:=Eachin Self
-				map.Set(defValue,item)
-			End
-		End 
-		Return map
-	End
+'	Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False )
+'		'TEST DEBUGMODE
+'		'Let's say, normal version, where the list item become the map value
+'		#rem Bug 
+'			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
+'			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
+'		#end 
+'		Local map:=New Map<Int,T>()
+'		If populateWithIdx 
+'			Local offset:Int=-2147483648 'TODO, change for the const
+'			For Local item:=Eachin Self
+'				map.Set(offset,item)
+'				offset+=1
+'			End
+'		Else 
+'			For Local item:=Eachin Self
+'				map.Set(defValue,item)
+'			End
+'		End 
+'		Return map
+'	End
 
 	#rem wonkeydoc Counts the number of values in the list.
-	
 	Note: This method can be slow when used with large lists, as it must visit each value. If you just
 	want to know whether a list is empty or not, use [[Empty]] instead.
-
 	@return The number of values in the list.
-	
 	#end
-	Method Count:UInt() 'iDkP: UNSIGNED 32 bits!
+	Method Count:Int() 'iDkP: SIGNED 32 bits!
 		Local node:=_head._succ,n:=0
 		While node<>_head
 			node=node._succ
@@ -793,9 +511,7 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Converts the list to an array.
-	
 	@return An array containing the items in the list.
-	
 	#end
 	Method ToArray:T[]() ' Updated by iDkP
 		'iDkP: Pseudo operator, deprecated
@@ -810,7 +526,6 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Removes all values from the list.
-	
 	#end
 	Method Clear()
 		_head._succ=_head
@@ -818,35 +533,26 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Adds a value to the start of the list.
-	
 	@param value The value to add to the list.
-	
 	@return A new node containing the value.
-
 	#end
-	Method AddFirst:Node( value:T ) Virtual 
+	Method AddFirst:Node( value:T )
 		Local node:=New Node( value,_head._succ )
 		Return node
 	End
 	
 	#rem wonkeydoc Adds a value to the end of the list.
-
 	@param value The value to add to the list.
-	
 	@return A new node containing the value.
-
 	#end
-	Method AddLast:Node( value:T ) Virtual 
+	Method AddLast:Node( value:T )
 		Local node:=New Node( value,_head )
 		Return node
 	End
 	
 	#rem wonkeydoc Removes the first value in the list equal to a given value.
-	
 	@param value The value to remove.
-
 	@return True if a value was removed.
-		
 	#end
 	Method Remove:Bool( value:T )
 		Local node:=FindNode( value )
@@ -856,11 +562,8 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Removes the last value in the list equal to a given value.
-	
 	@param value The value to remove.
-	
 	@return True if a value was removed.
-		
 	#end
 	Method RemoveLast:Bool( value:T )
 		Local node:=FindLastNode( value )
@@ -870,11 +573,8 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Removes all values in the list equal to a given value.
-	
 	@param value The value to remove.
-	
 	@return The number of values removed.
-	
 	#end
 	Method RemoveEach:Int( value:T )
 		Local node:=_head._succ,n:=0
@@ -885,17 +585,14 @@ Class List<T> Implements IContainer<T>
 				n+=1
 			Else
 				node=node._succ
-			Endif
+			End
 		Wend
 		Return n
 	End
 	
 	#rem wonkeydoc Removes all values in the list that fulfill a condition.
-	
 	@param cond Condition to test.
-	
 	@return The number of values removed.
-	
 	#end
 	Method RemoveIf:Int( condition:Bool( value:T ) )
 		Local node:=_head._succ,n:=0
@@ -906,19 +603,17 @@ Class List<T> Implements IContainer<T>
 				n+=1
 			Else
 				node=node._succ
-			Endif
+			End
 		Wend
 		Return n
 	End
 	
 	#rem wonkeydoc Removes and returns the first value in the list.
-	
 	In debug builds, a runtime error will occur if the list is empty.
-	
 	@return The value removed from the list.
-
 	#end
 	Method RemoveFirst:T()
+		
 		DebugAssert( Not Empty )
 		
 		Local value:=_head._succ._value
@@ -927,13 +622,11 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Removes and returns the last value in the list.
-	
 	In debug builds, a runtime error will occur if the list is empty.
-	
 	@return The value removed from the list.
-
 	#end
 	Method RemoveLast:T()
+		
 		DebugAssert( Not Empty )
 		
 		Local value:=_head._pred._value
@@ -942,22 +635,16 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Adds a value to the end of the list.
-	
 	This method behaves identically to AddLast.
-	
 	@param value The value to add.
-	
 	#end
 	Method Add( value:T )
 		AddLast( value )
 	End
 	
 	#rem wonkeydoc Adds all values in an array or container to the end of the list.
-	
 	@param values The values to add.
-	
 	@param values The values to add.
-	
 	#end
 	Method AddAll( values:T[] )
 		For Local value:=Eachin values
@@ -972,11 +659,8 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Sorts the list.
-	
 	@param ascending True to sort the stack in ascending order, false to sort in descending order.
-	
 	@param compareFunc Function to be used to compare values when sorting.
-	
 	#end
 	Method Sort( ascending:Int=True )
 	
@@ -988,7 +672,7 @@ Class List<T> Implements IContainer<T>
 			Sort( Lambda:Int( x:T,y:T )
 				Return -(x<=>y)
 			End )
-		Endif
+		End
 	End
 
 	Method Sort( compareFunc:Int( x:T,y:T ) )
@@ -1022,7 +706,7 @@ Class List<T> Implements IContainer<T>
 							t=q
 							q=q._succ
 							qsize-=1
-						Endif
+						End
 					Else If psize
 						t=p
 						p=p._succ
@@ -1051,11 +735,8 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Joins the values in the string list.
-	
 	@param sepeator The separator to be used when joining values.
-	
 	@return The joined values.
-	
 	#end
 	Method Join:String( separator:String="" ) Where T=String
 		Return separator.Join( ToArray() )
@@ -1063,36 +744,53 @@ Class List<T> Implements IContainer<T>
 
 	#rem wonkeydoc Gets the head node of the list.
 	#end
-	Method HeadNode:Node()
+	Property HeadNode:Node()
 		Return _head
 	End
 	
 	#rem wonkeydoc Gets the first node in the list.
-	
+	@modified iDkP from GaragePixel
 	@return The first node in the list, or null if the list is empty.
-	
 	#end
-	Method FirstNode:Node()
+	Property FirstNode:Node()
+		'Method changed as property
 		If Not Empty Return _head._succ
 		Return Null
 	End
 	
 	#rem wonkeydoc Gets the last node in the list.
-	
+	@modified iDkP from GaragePixel
 	@return The last node in the list, or null if the list is empty.
-	
 	#end
-	Method LastNode:Node()
+	Property LastNode:Node()
+		'Method changed as property
+		If Not Empty Return _head._pred
+		Return Null
+	End
+
+	#rem wonkeydoc Gets the first node in the list.
+	@author iDkP from GragePixel
+	@return The first node in the list, or null if the list is empty.
+	#end
+	Method GetFirstNode:Node()
+		'It will cast the Node type automatically
+		If Not Empty Return _head._succ
+		Return Null
+	End
+	
+	#rem wonkeydoc Gets the last node in the list.
+	@author iDkP from GragePixel
+	@return The last node in the list, or null if the list is empty.
+	#end
+	Method GetLastNode:Node()
+		'It will cast the Node type automatically
 		If Not Empty Return _head._pred
 		Return Null
 	End
 	
 	#rem wonkeydoc Finds the first node in the list containing a value.
-	
 	@param value The value to find.
-	
 	@return The first node containing the value, or null if the value was not found.
-	
 	#end
 	Method FindNode:Node( value:T )
 		Local node:=_head._succ
@@ -1104,11 +802,8 @@ Class List<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Finds the last node in the list containing a value.
-	
 	@param value The value to find.
-	
 	@return The last node containing the value, or null if the value was not found.
-	
 	#end
 	Method FindLastNode:Node( value:T )
 		Local node:=_head._pred
@@ -1122,7 +817,7 @@ Class List<T> Implements IContainer<T>
 	#rem wonkeydoc Return a copy of the list
 	@return Copy of the list
 	#end
-	Method Copy:List<T>() 'Added by iDkP from GaragePixel
+	Method Copy:List<T>() 'Added by iDkP
 		'Added for consistency (there is an operator to copy a list, 
 		'but it is not obvious for a new user of the library)
 		Return New List<T>( Self )
@@ -1195,13 +890,12 @@ Class List<T> Implements IContainer<T>
 	'----------------------------------------------
 
 	#rem wonkeydoc Make the list's items unique. 
+	@author iDkP from GaragePixel
+	@since 2025-05-11
 	@param onPlace If False, return a copy of the List
 	@return Copy of the list or Null
 	#end
 	Method Dedup:List<T>( onPlace:Bool=True )
-		'
-		' iDkP from GaragePixel
-		' 2025-05-11
 		'
 		' Note:
 		'	"Dedup" for "Deduplicate"
@@ -1211,7 +905,7 @@ Class List<T> Implements IContainer<T>
 		Local atLeastTwo:=currList.HasOneOrTwo
 		If atLeastTwo=1 Return currList
 		
-		Local firstNode:List<T>.Node=currList.FirstNode()
+		Local firstNode:List<T>.Node=currList.FirstNode
 
 		If atLeastTwo=2
 			If firstNode.Value=firstNode.Succ.Value firstNode.Succ.Remove()
@@ -1241,6 +935,8 @@ Class List<T> Implements IContainer<T>
 	End 
 
 	#rem wonkeydoc Finds the first node in the list containing a value.
+	@author iDkP from GaragePixel
+	@since 2025-05-10
 	@param value The value to find.
 	@return The first node containing the value, or null if the value was not found.
 	#end	
@@ -1250,13 +946,12 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Add each keys from this (param) to self
+	@author iDkP from GaragePixel
+	@since 2025-05-10
 	@param This is the list to compare.
 	@param onPlace if False, returns a copy of the list, else nothing
 	#end
 	Method Append:List<T>( this:List<T>, onPlace:Bool=True ) 'Added by iDkP from GaragePixel
-		'
-		' iDkP from GaragePixel
-		' 2025-05-10
 		'
 		' Semi-sugar
 		'
@@ -1274,16 +969,16 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Add each item from this (param) that exist in self. 
+	@author iDkP from GaragePixel
+	@since 2025-05-10
+	@note Original algorithm for stdlib
+	@source https://github.com/GaragePixel/stdlib-for-mx2/tree/main
 	Each item will be unique and in the same order from the two original lists. 
 	Note: Make also unique the items in the two original list.
 	@param This The list to compare.
 	@param onPlace if False, returns a copy of the list, else nothing
 	#end	
 	Method Union:List<T>( this:List<T>,onPlace:Bool=True ) 'Added by iDkP from GaragePixel
-		'
-		' iDkP from GaragePixel
-		' 2025-05-10 - Original algorithm for stdlib: 
-		' https://github.com/GaragePixel/stdlib-for-mx2/tree/main
 		'
 		' Description:
 		' 	Add this to self, do not keep duplicates in the output list.
@@ -1314,13 +1009,12 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Keep all keys from self that exist in this (param)
+	@author iDkP from GaragePixel
+	@since 2025-05-12
 	@param This is the list to compare.
 	@param onPlace if False, returns a copy of the list, else nothing
 	#end	
 	Method Intersect:List<T>( this:List<T>, onPlace:Bool=True ) 'Added by iDkP from GaragePixel
-		'
-		' iDkP from GaragePixel
-		' 2025-05-12
 		'
 		' Keep in self the keys that exist in this
 		'
@@ -1348,13 +1042,12 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Remove all keys from self that exist in this (param)
+	@author iDkP from GaragePixel
+	@since 2025-05-12
 	@param This is the list to compare.
 	@param onPlace if False, returns a copy of the list, else nothing
 	#end
 	Method Diff:List<T>( this:List<T>, onPlace:Bool=True ) 'Added by iDkP from GaragePixel
-		'
-		' iDkP from GaragePixel
-		' 2025-05-12
 		'
 		' Remove all keys from self that exist in this
 		'


### PR DESCRIPTION
Added GetFirstNode(), GetLastNode()
We can choose to use the properties FirstNode/LastNode when casting isn't necessary.

----------------
Map, List, Stack
----------------

	MAP RANGE x2 (Undoned):
		Map can only works with 32 unigned integer

	POINTER:
		Pointers are back.
		There was a problem with pointers to classes, Node as a class of course, but also K and V (internals).
		This problem is now fixed.

	KEY AS Uint, Long and ULong: UNDONED
		Method ToMapUInt:Map<UInt,T>( defValue:UInt=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapLong:Map<Long,T>( defValue:Long=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapULong:Map<ULong,T>( defValue:ULong=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T2,T>, onPlace:Bool=True ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T,T2>, onPlace:Bool=True ) 'Added by iDkP
		Method ToMapByte:Map<T,Byte>( defValue:Byte=Null, populateWithIdx:Bool=False ) 'Added by iDkP

	Conversions who works:
		Operator To:Map<T,UInt>() 'Added by iDkP
		Method ToMapUByte:Map<T,UByte>( defValue:UByte=Null, populateWithIdx:Bool=False ) 'Added by iDkP

		Because T is a 32-bit internal pointer (the node) and is a signed integer, so T and Int work, but not Uint, Long, and ULong.		
		The C transpiler can't handle UInt, Long, and ULong as keys for Map (not my fault).

		This was a workaround:
			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756

	Conversions that should works but no (do not working in debug mode only)
		Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False ) 'Added by iDkP

		Not specific reason found.

	Works:
		Property HasOne:Bool() 'Added by iDkP
		Property HasTwo:Bool() 'Added by iDkP
		Property HasOneOrTwo:Byte() 'Added by iDkP
		Method HasLess:Bool( nbItems:UInt ) 'Added by iDkP
		Method HasMore:Bool( nbItems:UInt ) 'Added by iDkP
		Operator To:Map<T,UInt>() 'Added by iDkP
		Method ToMapByte:Map<T,Byte>( defValue:Byte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapUByte:Map<T,UByte>( defValue:UByte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T2,T>, onPlace:Bool=True ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T,T2>, onPlace:Bool=True ) 'Added by iDkP
		Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False ) 'Added by iDkP

	The sort filter was not the cause of the problem. 
	The set of combinatorial functions was not the cause of the problem.